### PR TITLE
Add basic tests and skill routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,52 @@
-# devin-exmp
+# SkillSwap
+
+SkillSwap is a peer-to-peer platform for teaching and learning micro-skills via quick video or chat sessions.
+
+## Tech Stack
+
+- **Frontend**: React, React Router, Tailwind CSS (via PostCSS)
+- **Backend**: Node.js, Express
+- **Database**: MongoDB
+- **Payments**: Stripe
+- **Auth**: Firebase Auth or Auth0
+
+## Local Development
+
+### Backend
+
+```bash
+cd backend
+npm install
+cp .env.example .env # update variables
+npm run dev
+```
+
+### Frontend
+
+```bash
+cd frontend
+npm install
+npm start
+```
+
+This will start the API on `http://localhost:4000` and the frontend on `http://localhost:3000`.
+
+## Project Structure
+
+- `backend/` - Express server and API routes
+- `frontend/` - React application
+- `.env.example` - sample environment variables for the backend
+
+## Running Tests
+
+Both the backend and frontend use Node's built-in test runner. Run tests from
+each directory:
+
+```bash
+npm test
+```
+
+Each project includes a simple sample test to verify that the setup works.
+
+Feel free to submit pull requests with improvements!
+

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,2 @@
+MONGO_URI=your_mongo_connection_string
+PORT=4000

--- a/backend/models/Session.js
+++ b/backend/models/Session.js
@@ -1,0 +1,11 @@
+const mongoose = require('mongoose');
+
+const sessionSchema = new mongoose.Schema({
+  teacher: { type: mongoose.Schema.Types.ObjectId, ref: 'User' },
+  student: { type: mongoose.Schema.Types.ObjectId, ref: 'User' },
+  skill: { type: mongoose.Schema.Types.ObjectId, ref: 'Skill' },
+  scheduledAt: Date,
+  duration: Number,
+});
+
+module.exports = mongoose.model('Session', sessionSchema);

--- a/backend/models/Skill.js
+++ b/backend/models/Skill.js
@@ -1,0 +1,11 @@
+const mongoose = require('mongoose');
+
+const skillSchema = new mongoose.Schema({
+  title: String,
+  description: String,
+  price: Number,
+  duration: Number,
+  tags: [String]
+});
+
+module.exports = mongoose.model('Skill', skillSchema);

--- a/backend/models/User.js
+++ b/backend/models/User.js
@@ -1,0 +1,9 @@
+const mongoose = require('mongoose');
+
+const userSchema = new mongoose.Schema({
+  email: String,
+  password: String,
+  name: String,
+});
+
+module.exports = mongoose.model('User', userSchema);

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "backend",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "node --test",
+    "start": "node server.js",
+    "dev": "nodemon server.js"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "dependencies": {
+    "cors": "^2.8.5",
+    "dotenv": "^16.0.3",
+    "express": "^4.18.2",
+    "mongoose": "^7.2.0"
+  },
+  "devDependencies": {
+    "nodemon": "^3.0.3"
+  }
+}

--- a/backend/routes/auth.js
+++ b/backend/routes/auth.js
@@ -1,0 +1,9 @@
+const express = require('express');
+const router = express.Router();
+
+// TODO: add auth routes
+router.post('/login', (req, res) => {
+  res.send('login');
+});
+
+module.exports = router;

--- a/backend/routes/sessions.js
+++ b/backend/routes/sessions.js
@@ -1,0 +1,9 @@
+const express = require('express');
+const router = express.Router();
+
+// TODO: add session routes
+router.get('/', (req, res) => {
+  res.send('sessions');
+});
+
+module.exports = router;

--- a/backend/routes/skills.js
+++ b/backend/routes/skills.js
@@ -1,0 +1,28 @@
+const express = require('express');
+const router = express.Router();
+
+// In-memory skills for demo purposes
+const skills = [
+  {
+    id: 1,
+    title: 'How to juggle',
+    description: 'Learn juggling in 10 minutes',
+    price: 0,
+    duration: 10,
+    tags: ['juggling', 'fun'],
+  },
+];
+
+// List skills
+router.get('/', (req, res) => {
+  res.json(skills);
+});
+
+// Create a new skill
+router.post('/', (req, res) => {
+  const skill = { id: skills.length + 1, ...req.body };
+  skills.push(skill);
+  res.status(201).json(skill);
+});
+
+module.exports = router;

--- a/backend/server.js
+++ b/backend/server.js
@@ -1,0 +1,37 @@
+const express = require('express');
+const mongoose = require('mongoose');
+const cors = require('cors');
+const dotenv = require('dotenv');
+
+dotenv.config();
+
+const app = express();
+app.use(cors());
+app.use(express.json());
+
+const authRoutes = require('./routes/auth');
+const skillRoutes = require('./routes/skills');
+const sessionRoutes = require('./routes/sessions');
+
+const PORT = process.env.PORT || 4000;
+
+app.get('/', (req, res) => {
+  res.json({ message: 'SkillSwap API' });
+});
+
+app.use('/api/auth', authRoutes);
+app.use('/api/skills', skillRoutes);
+app.use('/api/sessions', sessionRoutes);
+
+mongoose.connect(process.env.MONGO_URI || '', {
+  useNewUrlParser: true,
+  useUnifiedTopology: true,
+});
+
+mongoose.connection.on('connected', () => {
+  console.log('MongoDB connected');
+});
+
+app.listen(PORT, () => {
+  console.log(`Server running on port ${PORT}`);
+});

--- a/backend/test/sample.test.js
+++ b/backend/test/sample.test.js
@@ -1,0 +1,7 @@
+const assert = require('assert');
+const test = require('node:test');
+
+// Basic sanity test
+test('addition works', () => {
+  assert.strictEqual(1 + 1, 2);
+});

--- a/frontend/.babelrc
+++ b/frontend/.babelrc
@@ -1,0 +1,3 @@
+{
+  "presets": ["@babel/preset-env", "@babel/preset-react"]
+}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "frontend",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "node --test",
+    "start": "npx webpack serve"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^6.14.2"
+  },
+  "devDependencies": {
+    "@babel/core": "^7.22.9",
+    "@babel/preset-env": "^7.22.9",
+    "@babel/preset-react": "^7.22.5",
+    "babel-loader": "^9.1.3",
+    "webpack": "^5.88.2",
+    "webpack-cli": "^5.1.4",
+    "webpack-dev-server": "^4.15.1"
+  }
+}

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>SkillSwap</title>
+</head>
+<body>
+  <div id="root"></div>
+  <script src="/bundle.js"></script>
+</body>
+</html>

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,0 +1,13 @@
+import React from 'react';
+import { Routes, Route } from 'react-router-dom';
+import Home from './pages/Home';
+
+function App() {
+  return (
+    <Routes>
+      <Route path="/" element={<Home />} />
+    </Routes>
+  );
+}
+
+export default App;

--- a/frontend/src/components/SkillCard.js
+++ b/frontend/src/components/SkillCard.js
@@ -1,0 +1,14 @@
+import React from 'react';
+
+function SkillCard({ skill }) {
+  return (
+    <div className="border rounded p-4 mb-2">
+      <h2 className="text-xl font-semibold">{skill.title}</h2>
+      <p>{skill.description}</p>
+      <div className="text-sm text-gray-600">Duration: {skill.duration} min</div>
+      <div className="text-sm text-gray-600">Price: {skill.price === 0 ? 'Free' : `$${skill.price}`}</div>
+    </div>
+  );
+}
+
+export default SkillCard;

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,0 +1,3 @@
+body {
+  font-family: sans-serif;
+}

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -1,0 +1,12 @@
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import { BrowserRouter } from 'react-router-dom';
+import App from './App';
+import './index.css';
+
+const root = createRoot(document.getElementById('root'));
+root.render(
+  <BrowserRouter>
+    <App />
+  </BrowserRouter>
+);

--- a/frontend/src/pages/Home.js
+++ b/frontend/src/pages/Home.js
@@ -1,0 +1,21 @@
+import React from 'react';
+import SkillCard from '../components/SkillCard';
+
+function Home() {
+  const sampleSkill = {
+    title: 'How to juggle',
+    description: 'Learn juggling in 10 minutes',
+    price: 0,
+    duration: 10,
+    tags: ['juggling', 'fun'],
+  };
+
+  return (
+    <div className="p-4">
+      <h1 className="text-2xl font-bold mb-4">SkillSwap</h1>
+      <SkillCard skill={sampleSkill} />
+    </div>
+  );
+}
+
+export default Home;

--- a/frontend/test/sample.test.js
+++ b/frontend/test/sample.test.js
@@ -1,0 +1,7 @@
+const assert = require('assert');
+const test = require('node:test');
+
+test('array includes value', () => {
+  const arr = [1,2,3];
+  assert.ok(arr.includes(2));
+});

--- a/frontend/webpack.config.js
+++ b/frontend/webpack.config.js
@@ -1,0 +1,38 @@
+const path = require('path');
+
+module.exports = {
+  entry: './src/index.js',
+  output: {
+    path: path.resolve(__dirname, 'dist'),
+    filename: 'bundle.js',
+    publicPath: '/',
+  },
+  module: {
+    rules: [
+      {
+        test: /\.jsx?$/,
+        exclude: /node_modules/,
+        use: {
+          loader: 'babel-loader',
+          options: {
+            presets: ['@babel/preset-env', '@babel/preset-react'],
+          },
+        },
+      },
+      {
+        test: /\.css$/,
+        use: ['style-loader', 'css-loader'],
+      },
+    ],
+  },
+  resolve: {
+    extensions: ['.js', '.jsx'],
+  },
+  devServer: {
+    static: {
+      directory: path.join(__dirname, 'public'),
+    },
+    historyApiFallback: true,
+    port: 3000,
+  },
+};


### PR DESCRIPTION
## Summary
- add simple skill routes returning in-memory data
- configure Node's test runner for backend and frontend
- add sample tests for backend and frontend
- document how to run tests in README

## Testing
- `npm test` in `backend`
- `npm test` in `frontend`
